### PR TITLE
Fix fromstr

### DIFF
--- a/tests/interval/test_floatinterval.py
+++ b/tests/interval/test_floatinterval.py
@@ -1,4 +1,4 @@
-from verry.interval.floatinterval import FloatConverter
+from verry.interval.floatinterval import FloatConverter, FloatInterval
 from verry.interval.interval import RoundingMode
 from verry.misc.formatspec import FormatSpec
 
@@ -7,6 +7,9 @@ def test_converter():
     ROUND_CEILING = RoundingMode.ROUND_CEILING
     ROUND_FLOOR = RoundingMode.ROUND_FLOOR
     converter = FloatConverter()
+
+    assert converter.fromint(9007199254740993, ROUND_FLOOR) == 9007199254740992.0
+    assert converter.fromint(9007199254740993, ROUND_CEILING) == 9007199254740994.0
 
     assert converter.format(0.001, FormatSpec(".3f"), ROUND_CEILING) == "0.002"
     assert converter.format(0.001, FormatSpec(".3f"), ROUND_FLOOR) == "0.001"

--- a/uv.lock
+++ b/uv.lock
@@ -537,7 +537,7 @@ wheels = [
 
 [[package]]
 name = "verry"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "mpmath" },


### PR DESCRIPTION
Reduce the case that `FloatConverter.fromstr` does not return the nearest floating-point number.
